### PR TITLE
[FIX] Bug when initializing multiple SPI slave strings

### DIFF
--- a/src/app/application/config/battery_system_cfg.h
+++ b/src/app/application/config/battery_system_cfg.h
@@ -96,7 +96,7 @@ typedef enum {
  *          repetition macro is adapted.
  * @ptype   uint
  */
-#define BS_NR_OF_STRINGS (1u)
+#define BS_NR_OF_STRINGS (2u)
 
 /* safety check: due to implementation BS_NR_OF_STRINGS may not be larger than GEN_REPEAT_MAXIMUM_REPETITIONS */
 #if (BS_NR_OF_STRINGS > GEN_REPEAT_MAXIMUM_REPETITIONS)

--- a/src/app/driver/config/spi_cfg.c
+++ b/src/app/driver/config/spi_cfg.c
@@ -86,50 +86,24 @@
  */
 
 /** SPI data configuration struct for ADI communication */
-static spiDAT1_t spi_kAdiDataConfig[BS_NR_OF_STRINGS] = {
-    {                      /* struct is implemented in the TI HAL and uses uppercase true and false */
-     .CS_HOLD = TRUE,      /* If true, HW chip select kept active between words */
-     .WDEL    = FALSE,     /* Activation of delay between words */
-     .DFSEL   = SPI_FMT_0, /* Data word format selection */
-     /* Hardware chip select is configured automatically depending on configuration in #SPI_INTERFACE_CONFIG_s */
-     .CSNR = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL},
-};
+spiDAT1_t spi_kAdiDataConfig[BS_NR_OF_STRINGS];
 
 /** SPI data configuration struct for LTC communication */
-static spiDAT1_t spi_kLtcDataConfig[BS_NR_OF_STRINGS] = {
-    {                      /* struct is implemented in the TI HAL and uses uppercase true and false */
-     .CS_HOLD = TRUE,      /* If true, HW chip select kept active between words */
-     .WDEL    = FALSE,     /* Activation of delay between words */
-     .DFSEL   = SPI_FMT_0, /* Data word format selection */
-     /* Hardware chip select is configured automatically depending on configuration in #SPI_INTERFACE_CONFIG_s */
-     .CSNR = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL},
-};
+spiDAT1_t spi_kLtcDataConfig[BS_NR_OF_STRINGS];
+
+/** SPI data configuration struct for NXP MC33775A communication, Tx part */
+spiDAT1_t spi_kNxp775DataConfigTx[BS_NR_OF_STRINGS];
+
+/** SPI data configuration struct for NXP MC33775A communication, Rx part */
+spiDAT1_t spi_kNxp775DataConfigRx[BS_NR_OF_STRINGS];
 
 /** SPI data configuration struct for MXM communication */
-static spiDAT1_t spi_kMxmDataConfig = {
+spiDAT1_t spi_kMxmDataConfig = {
     .CS_HOLD = TRUE,      /* If true, HW chip select kept active */
     .WDEL    = TRUE,      /* Activation of delay between words */
     .DFSEL   = SPI_FMT_1, /* Data word format selection */
     /* Hardware chip select is configured automatically depending on configuration in #SPI_INTERFACE_CONFIG_s */
     .CSNR = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL,
-};
-
-/** SPI data configuration struct for NXP MC33775A communication, Tx part */
-static spiDAT1_t spi_kNxp775DataConfigTx[BS_NR_OF_STRINGS] = {
-    {.CS_HOLD = TRUE,      /* If true, HW chip select kept active */
-     .WDEL    = TRUE,      /* Activation of delay between words */
-     .DFSEL   = SPI_FMT_2, /* Data word format selection */
-     /* Hardware chip select is configured automatically depending on configuration in #SPI_INTERFACE_CONFIG_s */
-     .CSNR = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL},
-};
-
-/** SPI data configuration struct for NXP MC33775A communication, Rx part */
-static spiDAT1_t spi_kNxp775DataConfigRx[BS_NR_OF_STRINGS] = {
-    {.CS_HOLD = TRUE,      /* If true, HW chip select kept active */
-     .WDEL    = TRUE,      /* Activation of delay between words */
-     .DFSEL   = SPI_FMT_2, /* Data word format selection */
-     /* Hardware chip select is configured automatically depending on configuration in #SPI_INTERFACE_CONFIG_s */
-     .CSNR = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL},
 };
 
 /** SPI data configuration struct for FRAM communication */
@@ -178,28 +152,26 @@ static spiDAT1_t spi_kSbcDataConfig = {
  * SPI interface configuration for ADI communication
  * This is a list of structs because of multistring
  */
-SPI_INTERFACE_CONFIG_s spi_adiInterface[BS_NR_OF_STRINGS] = {
-    {
-        .pConfig  = &spi_kAdiDataConfig[0u],
-        .pNode    = spiREG1,
-        .pGioPort = &(spiREG1->PC3),
-        .csPin    = SPI_ADI_CHIP_SELECT_PIN,
-        .csType   = SPI_CHIP_SELECT_HARDWARE,
-    },
-};
-
+SPI_INTERFACE_CONFIG_s spi_adiInterface[BS_NR_OF_STRINGS];
 /**
  * SPI interface configuration for LTC communication
  * This is a list of structs because of multistring
  */
-SPI_INTERFACE_CONFIG_s spi_ltcInterface[BS_NR_OF_STRINGS] = {
-    {
-        .pConfig  = &spi_kLtcDataConfig[0u],
-        .pNode    = spiREG1,
-        .pGioPort = &(spiREG1->PC3),
-        .csPin    = SPI_LTC_CHIP_SELECT_PIN,
-        .csType   = SPI_CHIP_SELECT_HARDWARE,
-    },
+SPI_INTERFACE_CONFIG_s spi_ltcInterface[BS_NR_OF_STRINGS];
+
+/** SPI interface configuration for N775 communication Tx part */
+SPI_INTERFACE_CONFIG_s spi_nxp775InterfaceTx[BS_NR_OF_STRINGS];
+
+/** SPI interface configuration for N775 communication, Rx part */
+SPI_INTERFACE_CONFIG_s spi_nxp775InterfaceRx[BS_NR_OF_STRINGS];
+
+/** SPI interface configuration for FRAM communication */
+SPI_INTERFACE_CONFIG_s spi_framInterface = {
+    .pConfig  = &spi_kFramDataConfig,
+    .pNode    = spiREG3,
+    .pGioPort = &(spiREG3->PC3),
+    .csPin    = SPI_FRAM_CHIP_SELECT_PIN,
+    .csType   = SPI_CHIP_SELECT_SOFTWARE,
 };
 
 /** SPI interface configuration for MXM communication */
@@ -209,37 +181,6 @@ SPI_INTERFACE_CONFIG_s spi_mxmInterface = {
     .pGioPort = &(spiREG4->PC3),
     .csPin    = SPI_MAXIM_CHIP_SELECT_PIN,
     .csType   = SPI_CHIP_SELECT_HARDWARE,
-};
-
-/** SPI interface configuration for N775 communication Tx part */
-SPI_INTERFACE_CONFIG_s spi_nxp775InterfaceTx[BS_NR_OF_STRINGS] = {
-    {
-        .pConfig  = &spi_kNxp775DataConfigTx[0u],
-        .pNode    = spiREG1,
-        .pGioPort = &(spiREG1->PC3),
-        .csPin    = SPI_NXP_TX_CHIP_SELECT_PIN,
-        .csType   = SPI_CHIP_SELECT_HARDWARE,
-    },
-};
-
-/** SPI interface configuration for N775 communication, Rx part */
-SPI_INTERFACE_CONFIG_s spi_nxp775InterfaceRx[BS_NR_OF_STRINGS] = {
-    {
-        .pConfig  = &spi_kNxp775DataConfigRx[0u],
-        .pNode    = spiREG4,
-        .pGioPort = &(spiREG4->PC3),
-        .csPin    = SPI_NXP_RX_CHIP_SELECT_PIN,
-        .csType   = SPI_CHIP_SELECT_HARDWARE,
-    },
-};
-
-/** SPI interface configuration for FRAM communication */
-SPI_INTERFACE_CONFIG_s spi_framInterface = {
-    .pConfig  = &spi_kFramDataConfig,
-    .pNode    = spiREG3,
-    .pGioPort = &(spiREG3->PC3),
-    .csPin    = SPI_FRAM_CHIP_SELECT_PIN,
-    .csType   = SPI_CHIP_SELECT_SOFTWARE,
 };
 
 /** SPI interface configuration for SPS communication */

--- a/src/app/driver/spi/spi.c
+++ b/src/app/driver/spi/spi.c
@@ -76,6 +76,11 @@
 /*========== Static Constant and Variable Definitions =======================*/
 static uint32_t spi_txLastWord[DMA_NUMBER_SPI_INTERFACES] = {0};
 
+extern spiDAT1_t spi_kLtcDataConfig[BS_NR_OF_STRINGS];
+extern spiDAT1_t spi_kAdiDataConfig[BS_NR_OF_STRINGS];
+extern spiDAT1_t spi_kNxp775DataConfigTx[BS_NR_OF_STRINGS];
+extern spiDAT1_t spi_kNxp775DataConfigRx[BS_NR_OF_STRINGS];
+
 /** Defines for hardware chip select pins @{ */
 #define SPI_HARDWARE_CHIP_SELECT_PIN_0 (0u)
 #define SPI_HARDWARE_CHIP_SELECT_PIN_1 (1u)
@@ -88,7 +93,8 @@ static uint32_t spi_txLastWord[DMA_NUMBER_SPI_INTERFACES] = {0};
 /*========== Extern Constant and Variable Definitions =======================*/
 
 /*========== Static Function Prototypes =====================================*/
-static void SPI_InitializeChipSelects(void);
+
+static void SPI_InitializeConfiguration(void);
 static uint8_t SPI_GetChipSelectPin(SPI_CHIP_SELECT_TYPE_e chipSelectType, uint32_t chipSelectPin);
 static uint8_t SPI_GetHardwareChipSelectPin(uint8_t chipSelectPin);
 
@@ -135,12 +141,60 @@ static uint8_t SPI_GetChipSelectPin(SPI_CHIP_SELECT_TYPE_e chipSelectType, uint3
 
     return mappedChipSelectPin;
 }
-static void SPI_InitializeChipSelects(void) {
+/*
+    * @brief   Initializes the configuration of SPI interfaces.
+    */
+static void SPI_InitializeConfiguration(void) {
     for (uint8_t s = 0u; s < BS_NR_OF_STRINGS; s++) {
-        spi_adiInterface[s].pConfig->CSNR = SPI_GetChipSelectPin(spi_adiInterface[s].csType, spi_adiInterface[s].csPin);
+        spi_ltcInterface[s].pConfig  = &spi_kLtcDataConfig[s];
+        spi_ltcInterface[s].pNode    = spiREG1;
+        spi_ltcInterface[s].pGioPort = &(spiREG1->PC3);
+        // Make sure to only use as many chip selects as available!
+        spi_ltcInterface[s].csPin  = SPI_LTC_CHIP_SELECT_PIN + s;
+        spi_ltcInterface[s].csType = SPI_CHIP_SELECT_HARDWARE;
+
+        spi_ltcInterface[s].pConfig->CS_HOLD = TRUE;
+        spi_ltcInterface[s].pConfig->WDEL    = FALSE;
+        spi_ltcInterface[s].pConfig->DFSEL   = SPI_FMT_0;
+        spi_ltcInterface[s].pConfig->CSNR    = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL;
         spi_ltcInterface[s].pConfig->CSNR = SPI_GetChipSelectPin(spi_ltcInterface[s].csType, spi_ltcInterface[s].csPin);
+
+        spi_adiInterface[s].pConfig  = &spi_kAdiDataConfig[s];
+        spi_adiInterface[s].pNode    = spiREG1;
+        spi_adiInterface[s].pGioPort = &(spiREG1->PC3);
+        // Make sure to only use as many chip selects as available!
+        spi_adiInterface[s].csPin  = SPI_ADI_CHIP_SELECT_PIN + s;
+        spi_adiInterface[s].csType = SPI_CHIP_SELECT_HARDWARE;
+
+        spi_adiInterface[s].pConfig->CS_HOLD = TRUE;
+        spi_adiInterface[s].pConfig->WDEL    = FALSE;
+        spi_adiInterface[s].pConfig->DFSEL   = SPI_FMT_0;
+        spi_adiInterface[s].pConfig->CSNR    = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL;
+        spi_adiInterface[s].pConfig->CSNR = SPI_GetChipSelectPin(spi_adiInterface[s].csType, spi_adiInterface[s].csPin);
+
+        spi_nxp775InterfaceTx[s].pConfig  = &spi_kNxp775DataConfigTx[s];
+        spi_nxp775InterfaceTx[s].pNode    = spiREG1;
+        spi_nxp775InterfaceTx[s].pGioPort = &(spiREG1->PC3);
+        // Make sure to only use as many chip selects as available!
+        spi_nxp775InterfaceTx[s].csPin            = SPI_NXP_TX_CHIP_SELECT_PIN + s;
+        spi_nxp775InterfaceTx[s].csType           = SPI_CHIP_SELECT_HARDWARE;
+        spi_nxp775InterfaceTx[s].pConfig->CS_HOLD = TRUE;
+        spi_nxp775InterfaceTx[s].pConfig->WDEL    = TRUE;
+        spi_nxp775InterfaceTx[s].pConfig->DFSEL   = SPI_FMT_2;
+        spi_nxp775InterfaceTx[s].pConfig->CSNR    = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL;
         spi_nxp775InterfaceTx[s].pConfig->CSNR =
             SPI_GetChipSelectPin(spi_nxp775InterfaceTx[s].csType, spi_nxp775InterfaceTx[s].csPin);
+
+        spi_nxp775InterfaceRx[s].pConfig  = &spi_kNxp775DataConfigRx[s];
+        spi_nxp775InterfaceRx[s].pNode    = spiREG1;
+        spi_nxp775InterfaceRx[s].pGioPort = &(spiREG1->PC3);
+        // Make sure to only use as many chip selects as available!
+        spi_nxp775InterfaceRx[s].csPin            = SPI_NXP_RX_CHIP_SELECT_PIN + s;
+        spi_nxp775InterfaceRx[s].csType           = SPI_CHIP_SELECT_HARDWARE;
+        spi_nxp775InterfaceRx[s].pConfig->CS_HOLD = TRUE;
+        spi_nxp775InterfaceRx[s].pConfig->WDEL    = TRUE;
+        spi_nxp775InterfaceRx[s].pConfig->DFSEL   = SPI_FMT_2;
+        spi_nxp775InterfaceRx[s].pConfig->CSNR    = SPI_HARDWARE_CHIP_SELECT_DISABLE_ALL;
         spi_nxp775InterfaceRx[s].pConfig->CSNR =
             SPI_GetChipSelectPin(spi_nxp775InterfaceRx[s].csType, spi_nxp775InterfaceRx[s].csPin);
     }
@@ -153,7 +207,7 @@ static void SPI_InitializeChipSelects(void) {
 /*========== Extern Function Implementations ================================*/
 extern void SPI_Initialize(void) {
     spiInit();
-    SPI_InitializeChipSelects();
+    SPI_InitializeConfiguration();
 }
 
 extern STD_RETURN_TYPE_e SPI_TransmitDummyByte(SPI_INTERFACE_CONFIG_s *pSpiInterface, uint32_t delay) {


### PR DESCRIPTION
@foxBMS 
For reference, please find a possible fix for handling multiple SPI slaves. The currently existing method initializes SPI interfaces in  the following way: 
`SPI_INTERFACE_CONFIG_s spi_ltcInterface[BS_NR_OF_STRINGS] = {
    {
        .pConfig  = &spi_kLtcDataConfig[0u],},};`
However, this only works as intended if `BS_NR_OF_STRINGS` equals 1 - `spi_ltcInterface[].pConfig` holds a null pointer for every instance apart from the first one. Verified using the Ozone Debugger, standard setup for foxBMS setup followed.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/b54bb7a7-3419-4193-938e-5e1218001ae0">


I'd appreciate it if you can include something like this in a future foxBMS release.



# Please read this before creating a Pull Request

The foxBMS project is an open source project to empower everybody to build
beyond state of the art battery management systems (BMS) based on software and
hardware that:

- **does not** compromise their outcomes with restricted licenses and
- **does not** create a vendor lock-in.

We therefore release foxBMS with permissive licenses:

- Hardware (layout, schematics) and documentation:
  **Creative Commons Attribution 4.0 International License (SPDX short identifier: CC-BY-4.0)**
- Software: **BSD 3-Clause License (SPDX short identifier: BSD-3-Clause)**

For details see the [LICENSE.md](../LICENSE.md) file and the
[license documentation](https://iisb-foxbms.iisb.fraunhofer.de/foxbms/gen2/docs/html/latest/general/licenses.html).

However foxBMS is not openly developed on GitHub (or any other platform). The
main development on this project is done by members of the Fraunhofer IISB and
organized in a non-public repository at the Fraunhofer IISB. This repository is
the output of the release branch of this internal repository.

This workflow allows us to release these development outputs under these
permissive licenses. We do not have a Contributors License Agreement (CLA)
system or similar that would allow us to integrate input from GitHub Pull
Requests, therefore GitHub Pull Requests are currently not accepted.

We would be very pleased if you intend to contribute to this project. Please
contact us first at <info@foxbms.org> in order to discuss your contribution and
how it can be applied to the project.
